### PR TITLE
Upgrade Jinja2 (and align with production versions)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
-flask==1.0.2
-GitPython==3.0.6
-
-## This is for building the static pages
 # This is what we actually install
 mkdocs==1.1.2
 mkdocs-material==6.1.0
@@ -12,6 +8,9 @@ pymdown-extensions==8.0.1
 mkdocs-windmill==1.0.0
 #mkdocs-rtd-dropdown==1.0.2
 
+GitPython==3.0.6
+flask==1.0.2
+
 # These are dependencies of the above
 backports-abc==0.5
 backports.ssl-match-hostname==3.5.0.1
@@ -20,14 +19,18 @@ certifi==2017.11.5
 click==7.1.2
 future==0.18.2
 html5lib==1.0.1
+importlib-metadata==2.0.0
 Jinja2==2.11.2
+joblib==0.17.0
 livereload==2.6.3
+lunr==0.5.8
 Markdown==3.3.2
 MarkupSafe==1.1.1
 nltk==3.5
 Pygments==2.7.1
 pytoml==0.1.14
 PyYAML==5.3.1
+regex==2020.10.15
 singledispatch==3.4.0.3
 six==1.15.0
 tornado==6.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ click==7.1.2
 future==0.18.2
 html5lib==1.0.1
 importlib-metadata==2.0.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 joblib==0.17.0
 livereload==2.6.3
 lunr==0.5.8


### PR DESCRIPTION
Upgraded Jinja2 and align the versions better with https://docs.csc.fi production