### PR TITLE
Remove an unnecessary dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ yasha==4.1
 mkdocs-windmill==1.0.0
 #mkdocs-rtd-dropdown==1.0.2
 mkdocs-redirects==1.2.0
-mkdocs-section-index==0.3.4
 
 # These are dependencies of the above
 Babel==2.10.3


### PR DESCRIPTION
The feature the _mkdocs-section-index_ plugin provides is already provided by Material for MkDocs. There's also a [PR for Docs](https://github.com/CSCfi/csc-user-guide/pull/1612).