### PR TITLE
Synchronize dependencies with csc-user-guide

### DIFF
--- a/app.py
+++ b/app.py
@@ -97,7 +97,7 @@ def buildRef(repo, ref, state):
     print("buildpath = %s" % (buildpath))
     mkdirp(buildpath)
 
-    scripts=["generate_alpha.sh","generate_by_system.sh","generate_new.sh"]
+    scripts=["generate_alpha.sh","generate_by_system.sh","generate_new.sh","generate_glossary.sh"]
 
     for script in scripts:
         cmd = "sh -c 'cd %s && ./scripts/%s 2>&1'" % (config["workPath"],script)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ MarkupSafe==2.1.1
 mergedeep==1.3.4
 packaging==21.3
 Pygments==2.15.0
-pymdown-extensions==10.0
+pymdown-extensions==10.3.1
 pyparsing==3.0.9
 python-dateutil==2.8.2
 pytz==2022.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,45 +1,37 @@
-flask==2.2.5
-GitPython==3.1.32
+# Packages for preview
+# (commented-out already satisfied in packages for static sites)
+# GitPython==3.1.37
+Flask==2.2.5
 
-## This is for building the static pages
+# Dependencies for preview
+# click==8.1.3
+# gitdb==4.0.9
+# importlib-metadata==4.12.0
+itsdangerous==2.1.2
+# Jinja2==3.1.2
+# MarkupSafe==2.1.1
+# smmap==5.0.0
+werkzeug==2.3.7
+# zipp==3.8.1
+
+
+# Packages for building the static pages
 # This is what we actually install
 mkdocs==1.3.1
 mkdocs-git-revision-date-localized-plugin==1.1.0
 mkdocs-material==8.4.0
 mkdocs-material-extensions==1.0.3
-mkdocs-git-revision-date-localized-plugin==1.1.0
-mdx-linkify==1.0
-mdx-environment==0.2.0
-yasha==4.1
-mkdocs-windmill==1.0.0
-#mkdocs-rtd-dropdown==1.0.2
 mkdocs-redirects==1.2.0
 mkdocs-section-index==0.3.4
 
 # These are dependencies of the above
 Babel==2.10.3
+click==8.1.3
 ghp-import==2.1.0
 gitdb==4.0.9
-backports-abc==0.5
-backports.ssl-match-hostname==3.5.0.1
-bleach==3.3.0
-certifi==2023.7.22
-click==8.1.3
-future==0.18.3
-html5lib==1.0.1
+GitPython==3.1.37
 importlib-metadata==4.12.0
 Jinja2==3.1.2
-joblib==1.2.0
-livereload==2.6.3
-lunr==0.5.8
-nltk>=3.6.4
-pytoml==0.1.14
-regex>=2020.10.15
-singledispatch==3.4.0.3
-six==1.16.0
-tornado==6.3.3
-tqdm==4.50.2
-webencodings==0.5.1
 Markdown==3.3.7
 MarkupSafe==2.1.1
 mergedeep==1.3.4
@@ -51,7 +43,7 @@ python-dateutil==2.8.2
 pytz==2022.2.1
 PyYAML==6.0
 pyyaml-env-tag==0.1
-xmltodict==0.11.0
+six==1.16.0
 smmap==5.0.0
 watchdog==2.1.9
 zipp==3.8.1


### PR DESCRIPTION
ATM (of writing), this branch is equal to _devel_ that's deployed at https://docs-preview-devel-csc-user-guide-preview.rahtiapp.fi

- revise requirements.txt (_pymdown_extensions_ v10.3.1 is ready to go in a PR at csc-user-guide)
- include glossary generation script (_/support/glossary_ AKA _/glossary_ wasn't working)