### PR TITLE
Add robots.txt file

### DIFF
--- a/helm/templates/docs-preview-deploy.yaml
+++ b/helm/templates/docs-preview-deploy.yaml
@@ -41,6 +41,8 @@ spec:
           name: content-vol
         - mountPath: /opt/bitnami/nginx/conf/server_blocks
           name: nginx-conf
+        - mountPath: /var/www/html/
+          name: robots-txt
       - env:
         - name: BUILDSECRET
           value: {{ .Values.secret }}
@@ -84,4 +86,8 @@ spec:
           defaultMode: 420
           name: nginx-config
         name: nginx-conf
+      - configMap:
+          defaultMode: 420
+          name: robots-txt
+        name: robots-txt
 status: {}

--- a/helm/templates/nginx-conf-configmap.yaml
+++ b/helm/templates/nginx-conf-configmap.yaml
@@ -8,6 +8,11 @@ data:
         index index.html;
         autoindex on;
       }
+
+      location = /robots.txt {
+        root /var/www/html;   # folder where robots.txt lives
+      }
+
       #rewrite ^/(.*[^/])$ $scheme://$http_host/$1/ permanent;
       port_in_redirect off;
     }

--- a/helm/templates/robots-configmap.yaml
+++ b/helm/templates/robots-configmap.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: robots-txt
+data:
+  robots.txt: |
+    User-agent: *
+    Disallow: /
+


### PR DESCRIPTION
Uses a config map to define `robots.txt` and mount it to `/var/www/html/`. Then nginx config is used to serve the robots.txt file.